### PR TITLE
support tag size warnings on input

### DIFF
--- a/www/css/nfcringapp.css
+++ b/www/css/nfcringapp.css
@@ -1774,3 +1774,10 @@ img.mfp-img {
 #sweetSpotOverlay{
   height:100%;
 }
+.dataWontFit{
+  display:none;
+  padding:10px;
+  margin:10px;
+  color: #9F6000;
+  background-color: #FEEFB3;  
+}

--- a/www/index.html
+++ b/www/index.html
@@ -106,6 +106,7 @@
       <label for="optionInput"></label>
       <input name="option" id="optionInput" type="text">
       <input type="hidden" id="actionHidden" name="action">
+      <div class="dataWontFit" id="dataWontFit"><h2>{{html10n "option.dataWontFit"}}</h2></div>
       <button type="submit" class="btn-link icon icon-next" id="submit">{{html10n "option.next"}}</button>
     </form>
   </div>

--- a/www/js/nfcRing/nfcEvent.js
+++ b/www/js/nfcRing/nfcEvent.js
@@ -53,6 +53,8 @@ nfcRing.nfcEvent = {
 
     if(nfcRing.userValues.activity == "register"){
       console.log("nfcEvent", nfcEvent);
+      nfcRing.userValues.tagSize = nfcEvent.tag.maxSize || nfcEvent.tag.freeSpaceSize; // saves the size
+      localStorage.setItem("tagSize", nfcRing.userValues.tagSize);
       nfcRing.userValues.uid = nfcEvent.tag.id.join(",");
       nfcRing.registration.isValidUid(function(isValid){
         if(isValid){

--- a/www/js/nfcRing/registration.js
+++ b/www/js/nfcRing/registration.js
@@ -29,7 +29,7 @@ nfcRing.registration = {
         }
       });
     }catch(e){
-      // Windows Phone wont do the Parse XHR request and fails on access is denied, this should be handled by the Parse API but $
+      // Windows Phone wont do the Parse XHR request and fails on access is denied, this should be handled by the Parse API but it isn't
       if(device.platform === "Win32NT"){
         $('#writeRingTitle').html("Windows Phone is unable to handle registrations at this time");
         console.log("Unable to process Parse on WP");

--- a/www/js/nfcRing/ui.js
+++ b/www/js/nfcRing/ui.js
@@ -131,6 +131,8 @@ nfcRing.ui = {
     });
 
     var language = localStorage.getItem("language");
+    nfcRing.userValues.tagSize = localStorage.getItem("tagSize") || 137;
+
 
     if(!language) language = navigator.language;
     console.log("Setting language to ", language);
@@ -200,6 +202,19 @@ nfcRing.ui = {
         nfcRing.userValues.isUrl = false;
       }
       $('.optionName').html('<h2>' + label + '</h2>');
+    });
+
+    $('body').on('change, keyup', '#optionInput', function(e){
+      var inputSize = $('#optionInput').val().length;
+      var tagSize = nfcRing.userValues.tagSize;
+      console.log("inputSize", inputSize, "tagSize", tagSize);
+      if(inputSize >= tagSize){
+        console.log("displaying warning because too much data is attempting to be written to me");
+        nfcRing.ui.dataSizeTooBig(true);
+      }else{
+        console.log("data should fit fine on the tag");
+        nfcRing.ui.dataSizeTooBig(false);
+      }
     });
 
     $('body').on('submit', '#optionForm', function(e){
@@ -419,5 +434,13 @@ nfcRing.ui = {
     var results = regex.exec( window.location.href );
     if( results == null ) return "";
     else return results[1];
+  },
+
+  dataSizeTooBig: function(wontFit){
+    if(wontFit){
+      $('.dataWontFit').show();
+    }else{
+      $('.dataWontFit').hide();
+    }
   }
 }

--- a/www/locales/en.json
+++ b/www/locales/en.json
@@ -21,6 +21,7 @@
   "context.history":"History",
   "action.whatDoYouWantYourRingToDo":"What do you want your ring to do?",
   "option.next":"Next",
+  "option.dataWontFit":"Warning: This amount of data might not fit on your NFC Ring",
   "writeRing.finish":"Finish",
   "writeRing.noNFC":"NFC functionality is not working. Is NFC enabled on your device?",
   "writeRing.woohoo":"Woohoo!",


### PR DESCRIPTION
1) By default assumes the tag has 137 bits of space, needs testing.

2) It gets the tagSize from the nfcEvent, this needs testing x-OS.

3) My code is not smart enough to know how URI's are encoded, when writing URLs sometimes you might specify "nfcring.com" and when the URI is written it might write "http://nfcring.com", this needs testing.

Once it has the tagSize it stores it in the localStorage then refers to it.

cc @Dmole for posterity
